### PR TITLE
Bump follow-redirects from 1.15.2 to 1.15.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,9 +4122,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
 			"dev": true,
 			"funding": [
 				{
@@ -10265,9 +10265,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
 			"dev": true
 		},
 		"form-data": {


### PR DESCRIPTION
### Description

This pull request includes changes to the version and integrity hashes of the `follow-redirects` package in the `package-lock.json` file. Here is a summary of the changes:

- The version of `follow-redirects` has been updated from `1.15.2` to `1.15.4`.
- The resolved URL for the package has been updated.
- The integrity hash for the package has been updated.

These changes ensure that the `follow-redirects` package is up to date and includes any bug fixes or improvements that have been made.

No additional information or requirements have been provided for this pull request.