### PR TITLE
Bump follow-redirects from 1.15.1 to 1.15.4 in /website

### DIFF
--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1454,9 +1454,9 @@ find-up@^4.0.0:
     path-exists "^4.0.0"
 
 follow-redirects@^1.0.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 forwarded@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Description

This pull request includes changes to the yarn.lock file.

The changes are as follows:

- Updated the version of follow-redirects from 1.15.1 to 1.15.4
  - Changed the resolved URL to "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
  - Updated the integrity checksum
- No other changes made to the yarn.lock file

These updates were made to ensure that the dependencies are up-to-date and to fix any potential vulnerabilities or bugs.