### PR TITLE
Bump follow-redirects from 1.15.1 to 1.15.4 in /samples

### DIFF
--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1776,7 +1776,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.1",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1784,7 +1786,6 @@
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
-			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -5742,7 +5743,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.15.1",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
 			"dev": true
 		},
 		"forwarded": {


### PR DESCRIPTION
### Description

The following changes are being made in this pull request:

- The version of the package "follow-redirects" in the package-lock.json file is being updated from 1.15.1 to 1.15.4.
- The "resolved" and "integrity" properties of the "follow-redirects" package in the package-lock.json file are being updated to reflect the new version.
- The "license" property of the "follow-redirects" package in the package-lock.json file is being removed.
- The version of the "follow-redirects" package in the package.json file is being updated from 1.15.1 to 1.15.4.
- The "resolved" and "integrity" properties of the "follow-redirects" package in the package.json file are being updated to reflect the new version.